### PR TITLE
fix/event-api

### DIFF
--- a/docs/developers/creating-your-first-plugin.md
+++ b/docs/developers/creating-your-first-plugin.md
@@ -28,14 +28,16 @@ Now we have created our project, we need configure our build system.
 
 ### Maven repository
 
-| Name | velocity                                                   |
+||
 |------|------------------------------------------------------------|
+| Name | velocity                                                   |
 | URL  | https://nexus.velocitypowered.com/repository/maven-public/ |
 
 ### Dependency
 
-| Group ID    | com.velocitypowered |
+||
 |-------------|---------------------|
+| Group ID    | com.velocitypowered |
 | Artifact ID | velocity-api        |
 | Version     | 1.1.0-SNAPSHOT      |
 

--- a/docs/developers/event-api.md
+++ b/docs/developers/event-api.md
@@ -3,6 +3,7 @@ title: Working With Events
 ---
 
 Listening to events with Velocity's `@Subscribe` annotation is straightforward. You've already seen one such listener, using the ProxyInitializeEvent in your main class.
+Additional events can be found on the [Javadoc](https://jd.velocitypowered.com/1.1.0/)
 
 ### Adding listening methods
 

--- a/docs/sidebar-wiki.json
+++ b/docs/sidebar-wiki.json
@@ -57,7 +57,7 @@
       },
       {
         "title": "The Event API",
-        "url": "/wiki/developers/listener/"
+        "url": "/wiki/developers/event-api/"
       },
       {
         "title": "The Command API",


### PR DESCRIPTION
Renamed the 'listener.md' file to 'event-api.md' to stay consistent internally.

Added a link to the Javadoc for additional event's