### PR TITLE
FabricProxy-Lite

### DIFF
--- a/docs/users/forwarding.md
+++ b/docs/users/forwarding.md
@@ -32,7 +32,7 @@ In `paper.yml`, set `settings.velocity-support.enabled` to true and `settings.ve
  
 ## Configuring modern forwarding for Fabric
 
-A mod called [FabricProxy](https://www.curseforge.com/minecraft/mc-mods/fabricproxy) allows you to use Velocity modern forwarding with a modded server using Fabric.
+A mod called [FabricProxy-Lite](https://www.curseforge.com/minecraft/mc-mods/fabricproxy-lite) allows you to use Velocity modern forwarding with a modded server using Fabric.
  
 ## Configuring legacy BungeeCord-compatible forwarding
 

--- a/docs/users/server-compatibility.md
+++ b/docs/users/server-compatibility.md
@@ -16,7 +16,7 @@ Velocity is best-tested with implementations derived from the vanilla server by 
 
 The Mojang vanilla software is in a complicated position. It is useful as we often produce protocol updates using the Mojang server for testing, but in production setups, the lack of player info forwarding support can induce subtle client problems.
 
-If you plan to run a vanilla server, **the Velocity team strongly recommends that you use Fabric with the FabricProxy mod**. Fabric and FabricProxy do not by themselves change the vanilla experience, and your server will remain compatible with vanilla clients. If you are unable (or unwilling) to run Fabric, [VanillaCord](https://github.com/ME1312/VanillaCord) allows you to use legacy BungeeCord forwarding.
+If you plan to run a vanilla server, **the Velocity team strongly recommends that you use Fabric with the FabricProxy-Lite mod**. Fabric and FabricProxy-Lite do not by themselves change the vanilla experience, and your server will remain compatible with vanilla clients. If you are unable (or unwilling) to run Fabric, [VanillaCord](https://github.com/ME1312/VanillaCord) allows you to use legacy BungeeCord forwarding.
 
 ### Spigot
 


### PR DESCRIPTION
FabricProxy is no longer maintained, it's recommended to use FabricProxy-Lite instead.
[more information here](https://github.com/OKTW-Network/FabricProxy#deprecated)