### PR TITLE
Fixed Downloads redirect

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -88,7 +88,7 @@ const NavbarExpand = styled.div`
 function NavbarItemContents({ location, onMobileClick }) {
   return <>
     <NavbarLink href={"https://docs.papermc.io/velocity"} onClick={onMobileClick}>Documentation</NavbarLink>
-    <NavbarLink href={"https://papermc.io/downloads#Velocity"} onClick={onMobileClick}>Downloads</NavbarLink>
+    <NavbarLink href={"https://papermc.io/downloads/velocity"} onClick={onMobileClick}>Downloads</NavbarLink>
     <NavbarItem href={"https://forums.papermc.io/"} onClick={onMobileClick}>Forums</NavbarItem>
     <NavbarItem href={"https://discord.gg/papermc"} onClick={onMobileClick}>Discord</NavbarItem>
     <NavbarItem href={"https://github.com/PaperMC/Velocity"} onClick={onMobileClick}>GitHub</NavbarItem>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -97,7 +97,7 @@ export default function Home() {
             <h1>Velocity</h1>
             <p>The modern, next-generation Minecraft server proxy.</p>
             <ButtonSection>
-              <MainPageButton icon={<FiDownload size={"32px"}/>} title={"Download Now"} link={"https://papermc.io/downloads#Velocity"} />
+              <MainPageButton icon={<FiDownload size={"32px"}/>} title={"Download Now"} link={"https://papermc.io/downloads/velocity"} />
               <MainPageButton icon={<FiBook size={"32px"}/>} title={"Learn More"} link={"https://docs.papermc.io/velocity"} />
             </ButtonSection>
           </div>
@@ -122,7 +122,7 @@ export default function Home() {
           <ExplainerTidbit>
             <h2>Always there for you.</h2>
             <p>
-              Velocity powers some of the world's largest Minecraft networks along with numerous small networks. Velocity can scale to thousands of players per proxy instance. Best of all, it works with Paper, Sponge, Forge, Fabric, and all versions of Minecraft from 1.7.2 to 1.19.3.
+              Velocity powers some of the world's largest Minecraft networks along with numerous small networks. Velocity can scale to thousands of players per proxy instance. Best of all, it works with Paper, Sponge, Forge, Fabric, and all versions of Minecraft from 1.7.2 to 1.19.4.
             </p>
           </ExplainerTidbit>
         </ExplainerSection>

--- a/static/_redirects
+++ b/static/_redirects
@@ -20,4 +20,4 @@
 /wiki/developers/pitfalls https://docs.papermc.io/velocity/dev/pitfalls
 /wiki/misc/credits https://docs.papermc.io/velocity/credits
 /wiki/* https://docs.papermc.io/velocity
-/downloads https://papermc.io/downloads#Velocity
+/downloads https://papermc.io/downloads/velocity


### PR DESCRIPTION
Paper recently changed its home page, and with it its download links.

Now the download link for Velocity has been moved to https://papermc.io/downloads/velocity instead of https://papermc.io/downloads#Velocity